### PR TITLE
Change MongoDB link from tide.csh to mongo.csh

### DIFF
--- a/deadass/templates/index.html
+++ b/deadass/templates/index.html
@@ -41,7 +41,7 @@
       <h2 class="pb-2 borber-bottom">Your Databases</h2>
       <p>
         <strong>Postgres:</strong> <a href="https://wiki.csh.rit.edu/wiki/PostgreSQL"><code>postgres.csh.rit.edu</code></a>,
-        <strong>Mongo:</strong> <a href="https://wiki.csh.rit.edu/wiki/Mongodb"><code>tide.csh.rit.edu</code></a>,
+        <strong>Mongo:</strong> <a href="https://wiki.csh.rit.edu/wiki/Mongodb"><code>mongo.csh.rit.edu</code></a>,
         <strong>mySQL:</strong> <a href="https://wiki.csh.rit.edu/wiki/Mysql"><code>mysql.csh.rit.edu</code></a>,
         <strong>S3:</strong> <a href="https://wiki.csh.rit.edu/wiki/S3"><code>s3.csh.rit.edu</code></a>
       </p>


### PR DESCRIPTION
Change MongoDB link from tide.csh.rit.edu to mongo.csh.rit.edu on landing page.