### PR TITLE
Add Alphanumeric Name Form Validation

### DIFF
--- a/deadass/__init__.py
+++ b/deadass/__init__.py
@@ -11,12 +11,13 @@ from flask_pyoidc.provider_configuration import ProviderConfiguration, ClientMet
 from flask import Flask, render_template, send_from_directory, redirect, abort, flash
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy_utils import database_exists, create_database
-from flask_pymongo import PyMongo
+from flask_pymongo import MongoClient
 from sqlalchemy import text, create_engine
 from sqlalchemy.orm import Session
 import requests
 import random
 import radosgw
+import urllib
 
 # from flask_login import login_user, logout_user, login_required, LoginManager, current_user
 
@@ -35,7 +36,7 @@ else:
 deadass_db = create_engine(app.config["DEADASS_URI"])
 postgres_db = create_engine(app.config["POSTGRES_URI"])
 mysql_db = create_engine(app.config["MYSQL_URI"])
-mongo_db = PyMongo(app)
+mongo_db = MongoClient(urllib.parse.quote_plus(app.config["MONGO_URI"]))
 rgwadmin = radosgw.connection.RadosGWAdminConnection(
     host=app.config["S3_HOST"],
     access_key=app.config["S3_ACCESS_KEY"],

--- a/deadass/forms.py
+++ b/deadass/forms.py
@@ -3,8 +3,13 @@
 # Author: Joe Abbate               #
 ####################################
 from flask_wtf import FlaskForm
-from wtforms import SubmitField, StringField, SelectField, Form
-from wtforms.validators import DataRequired
+from wtforms import Form, SelectField, StringField, SubmitField, validators
+from wtforms.validators import DataRequired, StopValidation
+
+
+def is_alphanumeric(form, field):
+    if not field.data.isalnum():
+        raise StopValidation("Name must be alphanumeric")
 
 
 class DBCreate(FlaskForm):
@@ -13,7 +18,7 @@ class DBCreate(FlaskForm):
         choices=[("POSTGRES", "PostgreSQL"), ("MYSQL", "MySQL"), ("MONGO", "Mongo")],
         validators=[DataRequired()],
     )
-    name = StringField("Database Name", validators=[DataRequired()])
+    name = StringField("Database Name", validators=[DataRequired(), is_alphanumeric])
     submit = SubmitField(("Submit"), validators=[DataRequired()])
 
     def validate(self, extra_validators=None):
@@ -21,8 +26,9 @@ class DBCreate(FlaskForm):
             return False
         return True
 
+
 class S3Create(FlaskForm):
-    name = StringField("S3 Username", validators=[DataRequired()])
+    name = StringField("S3 Username", validators=[DataRequired(), is_alphanumeric])
     submit = SubmitField(("Submit"), validators=[DataRequired()])
 
     def validate(self, extra_validators=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 Mako==1.2.3
 MarkupSafe==2.1.1
+mysqlclient==2.2.7
 oic==1.4.0
 packaging==23.2
 psycopg2==2.9.4


### PR DESCRIPTION
Adds form validation for the alphanumeric requirement for database names and S3 usernames, instead of users receiving a generic 500.
